### PR TITLE
buildscript for windows and mac

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -51,62 +51,24 @@ The product and section landing pages are achieved via [Vue](https://vuejs.org/)
 
 Sphinx projects are typically built with a `Makefile`. This project is built with a shell script instead. Once executed it generates a `build/output` directory inside `site`. The final static html pages are there.
 
-The Build script can take 0, 1, or 2 arguments. Usage and behavior is as follows:
+The Build script has two flavors: build for production or build a test site. Usage and behavior is as follows:
 
-General usage:
-
-```bash
-./build_site.sh [arg1:product] [arg2:version]
-```
-
-> Run it without arguments to build all of the docs site (all products) but not do the stuff for production (e.g., `git clean -dfx`). This is equivalent to passing the "all" argument.
-
-------------
-
-### Examples and Behaviors
-
-#### Build for Production
+Build for production:
 
 > **Warning:** Your docs folder is automatically subject to a
 >
 > `git clean -dfx`
 >
-> If you use this option. Only run this if you're building the site for publication.
+> If you use this option. In addition, the virtual environment will be deleted and all the applications re-installed (including Sphinx). Only run this if you're building the site for publication or if you know you need these options.
 
 ```bash
 ./build_site.sh prod
 ```
 
-**Behavior:** This provides the exact same behavior as before we began accepting arguments. We still need to figure out the cleanest way to call upload_to_server for only this usage. Includes a `git clean -dfx` on the docs folder.
-
-------------
-
-#### Build a Single Product's Default Version
-
-The default versions are hard-coded in the script (`2.x`, `7.x`, `latest`).
+Build for testing:
 
 ```bash
-./build_site.sh dxp-cloud [other valid values are `dxp` and `commerce`]
+./build_site.sh
 ```
 
-**Behavior:** Without git cleaning, build the specified product with the default version. Until we add more versions, there's no need to use the next example.
-
-------------
-
-#### Build a Single Product With a Specific Version
-
-```bash
-./build_site.sh dxp-cloud latest [other valid arg statements are `dxp 7.x` and `commerce 2.x`]
-```
-
-**Behavior:** Without git cleaning, build a single product with a specified version.
-
-------------
-
-#### Build All Products and Versions for Local Testing
-
-```bash
-./build_site.sh all
-```
-
-**Behavior:** Same behavior as [prod](#build-for-production) but `git clean -dfx` is not included. We'll also avoid calling `upload_to_server` as well.
+This builds all products and versions for local testing. Your git index is safe from cleaning and the virtual environment won't automatically be removed for you. It's advisable to start from scratch with each new branch you check out, manually deleting the `liferay-learn/site/build` folder and the `liferay-learn/site/venv` folder.

--- a/site/README.md
+++ b/site/README.md
@@ -32,10 +32,22 @@ The product and section landing pages are achieved via [Vue](https://vuejs.org/)
 
 ## Building the Site
 
-> **OS-specific pitfalls:** 
-> - _Windows:_ If you see an error like
->    `[./build_site.sh: line 220: /c/Users/liferay/AppData/Local/Microsoft/WindowsApps/python3: Permission denied` you probably have conflicting Python versions installed. To correct it, use the second part of this [StackOverflow post](https://stackoverflow.com/a/57168165/4325798) to fix it: "type `manage app execution aliases` into the Windows search prompt and disable [all] the store versions of Python altogether."
-> - _MacOS:_ This script requires `gnu-find` and `gnu-sed`. Make sure you have these installed (e.g., `brew install gnu-find/sed`)
+> **MacOS--Replace the `find` and `sed` tools:** 
+> This script requires the `gnu` versions of `find` and `sed`. You can install these and replace the default versions: 
+>
+>    1. Use `brew` to install the tools:
+>    
+>       brew install findutils
+>
+>       brew install gnu-sed
+>    
+>
+>    2. Prepend the PATH with the path to the new tools, so they will be used in place of the native `find` and `sed`:
+>
+>       export PATH="/usr/local/opt/findutils/libexec/gnubin:$PATH"
+>
+>       export PATH="/usr/local/opt/gnu-sed/libexec/gnubin:$PATH"
+>    
 
 Sphinx projects are typically built with a `Makefile`. This project is built with a shell script instead. Once executed it generates a `build/output` directory inside `site`. The final static html pages are there.
 

--- a/site/build_site.sh
+++ b/site/build_site.sh
@@ -51,15 +51,15 @@ function configure_env {
 		rm -fr venv
 	fi
 
-	if [[ "$(uname)" == "Linux" || "$(uname)" == "Darwin" ]]
+	if [[ "$(uname)" == "Darwin" || "$(uname)" == "Linux" ]]
 	then
-			python3 -m venv venv
+		python3 -m venv venv
 
-			source venv/bin/activate
+		source venv/bin/activate
 	else
-			python -m venv ${PWD}/venv
+		python -m venv ${PWD}/venv
 
-			source ${PWD}/venv/scripts/activate
+		source ${PWD}/venv/scripts/activate
 	fi
 
 	check_utils pip3 zip

--- a/site/build_site.sh
+++ b/site/build_site.sh
@@ -51,9 +51,16 @@ function configure_env {
 		rm -fr venv
 	fi
 
-	python3 -m venv venv
+	if [[ "$(uname)" == "Linux" || "$(uname)" == "Darwin" ]]
+	then
+			python3 -m venv venv
 
-	source venv/bin/activate
+			source venv/bin/activate
+	else
+			python -m venv ${PWD}/venv
+
+			source ${PWD}/venv/scripts/activate
+	fi
 
 	check_utils pip3 zip
 


### PR DESCRIPTION
Re-send. Sorry the last one was so sloppy.
On windows the venv setup is different than on Mac and Linux. Also, the `uname` on windows isn't consistent so I opted to check for Linux and Darwin.
We just needed to document how to install some gnu utilities on mac.