### PR TITLE
Search upgrade paths

### DIFF
--- a/docs/dxp/7.x/en/using-search/installing-and-upgrading-a-search-engine/elasticsearch.rst
+++ b/docs/dxp/7.x/en/using-search/installing-and-upgrading-a-search-engine/elasticsearch.rst
@@ -11,6 +11,7 @@ Elasticsearch
    elasticsearch/troubleshooting-elasticsearch-installation.md
    elasticsearch/exercise-installing-elasticsearch.md
    elasticsearch/using-the-sidecar-or-embedded-elasticsearch.md
+   elasticsearch/backing-up-elasticsearch.md
 
 Elasticsearch is the highly scalable, full-text search engine Liferay uses by default. Elasticsearch is bundled with Liferay for non-production purposes. In production, Liferay requires Elasticsearch running on separate remote server.
 
@@ -29,6 +30,7 @@ Installing
 -  :doc:`/using-search/installing-and-upgrading-a-search-engine/elasticsearch/connecting-to-elasticsearch`
 -  :doc:`/using-search/installing-and-upgrading-a-search-engine/elasticsearch/exercise-installing-elasticsearch`
 -  :doc:`/using-search/installing-and-upgrading-a-search-engine/elasticsearch/troubleshooting-elasticsearch-installation`
+-  :doc:`/using-search/installing-and-upgrading-a-search-engine/elasticsearch/backing-up-elasticsearch`
 
 - `[Clustering Liferay]` `Add a Search Engine to a Liferay Cluster <../../installation-and-upgrades/setting-up-liferay-dxp/clustering-for-high-availability/example-creating-a-simple-dxp-cluster.md#start-a-search-engine-server>`__
 

--- a/docs/dxp/7.x/en/using-search/installing-and-upgrading-a-search-engine/elasticsearch/backing-up-elasticsearch.md
+++ b/docs/dxp/7.x/en/using-search/installing-and-upgrading-a-search-engine/elasticsearch/backing-up-elasticsearch.md
@@ -1,0 +1,172 @@
+# Backing Up Elasticsearch
+
+[Elasticsearch replicas](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/index-modules.html#index-modules-settings) protect against a node going down, but they won't help you with a catastrophic failure. Only good backup practices can help you then.
+
+Back up your Elasticsearch cluster and test restoring the backup in three steps: 
+
+1. Create a repository
+
+1. Take a snapshot of the Elasticsearch cluster
+
+1. Restore from the snapshot
+
+```note::
+   For more detailed information, refer to Elastic's `Elasticsearch administration guide <https://www.elastic.co/guide/en/elasticsearch/guide/master/administration.html>`_, and in particular to the `Snapshot and Restore module <https://www.elastic.co/guide/en/elasticsearch/reference/7.x/snapshot-restore.html>`_.
+```
+
+## Create a Repository
+
+First [create a repository](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/snapshots-register-repository.html) to store your snapshots. Here are the supported repository types:
+
+* Shared file system, such as a Network File System or NAS
+* Amazon S3
+* HDFS (Hadoop Distributed File System)
+* Azure Cloud
+
+If you want to store snapshots on a shared file system, first register the path to the shared file system in each node's `elasticsearch.yml` using the [`path.repo` setting](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/snapshots-register-repository.html#snapshots-filesystem-repository). For example,
+
+```yaml
+path.repo: ["path/to/shared/file/system/"]
+```
+
+After registering the path to the folder hosting the repository (make sure the folder exists), create the repository with a `PUT` command. For example,
+
+```bash
+curl -X PUT "localhost:9200/_snapshot/test_backup" -H 'Content-Type: application/json' -d'
+{
+  "type": "fs",
+  "settings": {
+    "location": "/path/to/shared/file/system/"
+  }
+}'
+```
+
+Replace `localhost:9200` with your system's `hostname:port`, replace `test_backup` with the name of the repository to create, and replace the `location` setting value with the absolute path to your shared file system.
+
+If you created the repository correctly, the command returns this result:
+
+```json
+{"acknowledged":true}
+```
+
+Now that the repository exists, create a snapshot.
+
+## Take a Snapshot of the Cluster
+
+The easiest snapshot approach is to create a [snapshot of all the indexes in your cluster](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/snapshots-take-snapshot.html). For example,
+
+```bash
+curl -XPUT localhost:9200/_snapshot/test_backup/snapshot_1
+```
+
+A successful snapshot command returns this result:
+
+```json
+{"accepted":true}
+```
+
+You can limit snapshots to specific indexes too. For example, you may have Liferay Enterprise Search Monitoring but want to exclude monitoring indexes from the snapshot. Explicitly declare the indexes to include in the snapshot. For example,
+
+```bash
+curl -XPUT localhost:9200/_snapshot/test_backup/snapshot_2
+{ "indices": "liferay-0,liferay-20116" }
+```
+
+To list all indexes and index metrics, execute this command:
+
+```bash
+curl -X GET "localhost:9200/_cat/indices?v"
+```
+
+Example index metrics,
+
+```bash
+health status index         uuid                   pri rep docs.count docs.deleted store.size pri.store.size
+green  open   liferay-20099 obqiNE1_SDqfuz7rincrGQ   1   0        195            0    303.1kb        303.1kb
+green  open   liferay-47206 3YEjtye1S9OVT0i0EZcXcw   1   0          7            0     69.7kb         69.7kb
+green  open   liferay-0     shBWwpkXRxuAmGEaE475ug   1   0        147            1    390.9kb        390.9kb
+```
+
+```note::
+   Elasticsearch uses a *smart snapshots* approach. To understand what that means, consider a single index. The first snapshot includes a copy of the entire index, while subsequent snapshots only include the delta between the first, complete index snapshot and the current state of the index.
+```
+
+Eventually you'll end up with a lot of snapshots in your repository, and no matter how cleverly you name the snapshots, you may forget what some snapshots contain. You can get a snaptshot's description using the Elasticsearch API. For example,
+
+```bash
+curl -XGET localhost:9200/_snapshot/test_backup/snapshot_1
+```
+
+returns
+
+```json
+{"snapshots":[
+    {"snapshot":"snapshot_1",
+    "uuid":"WlSjvJwHRh-xlAny7zeW3w",
+    "version_id":6.80399,
+    "version":"6.8.2",
+    "indices":["liferay-20099","liferay-0","liferay-47206"],
+    "state":"SUCCESS",
+    "start_time":"2018-08-15T21:40:17.261Z",
+    "start_time_in_millis":1534369217261,
+    "end_time":"2018-08-15T21:40:17.482Z",
+    "end_time_in_millis":1534369217482,
+    "duration_in_millis":221,
+    "failures":[],
+    "shards":{
+        "total":3,
+        "failed":0,
+        "successful":3
+        
+        }
+    }
+]}
+```
+
+The snapshot information includes the time range of the indexes.
+
+If you want to discard a snapshot, use the `DELETE` command.
+
+```bash
+curl -XDELETE localhost:9200/_snapshot/test_backup/snapshot_1
+```
+
+Including all indexes in a snapshot can consume a lot of time and storage. If you start creating a snapshot by mistake (for example, wanted to filter on specific indexes but included all indexes) you can cancel snapshot processing using a `DELETE` command. By deleting the snapshot by name, the snapshot process terminates and the partial snapshot is removed from the repository.
+
+## Test Restoring from the Snapshot
+
+If a catastrophic failure occurs, what good is a snapshot if you can't [restore your search indexes](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/snapshots-restore-snapshot.html) from it? Use the `_restore` API to restore all the snapshot's indexes:
+
+```bash
+curl -XPOST localhost:9200/_snapshot/test_backup/snapshot_1/_restore
+```
+
+To restore specific indexes, use the `indices` option, and rename the indexes using the `rename_pattern` and `rename_replacement` options:
+
+```bash
+curl -XPOST
+localhost:9200/_snapshot/test_backup/snapshot_1/_restore
+{
+    "indices": "liferay-20116",
+    "rename_pattern": "liferayindex_(.+)",
+    "rename_replacement": "restored_liferayindex_$1"
+}
+```
+
+This restores only the index named `liferay-20116index_1` from the snapshot. The `rename...` settings specify to replace the beginning `liferayindex_` with `restored_liferayindex_`, so `liferay-20116index_1` becomes `restored_liferay-20116index_1`.
+
+As with the canceling a snapshot process, you can use the `DELETE` command to cancel an errant restore process:
+
+```bash
+curl -XDELETE localhost:9200/restored_liferay-20116index_3
+```
+
+Nobody likes catastrophic failure on a production system, but Elasticsearch's API for taking snapshots and restoring indexes can help you rest easy knowing that your search cluster can be restored if disaster strikes. For more details and options, read Elastic's [Snapshot and Restore documentation](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/snapshot-restore.html).
+
+## What's Next
+
+If you want to [upgrade Elasticsearch](./upgrading-elasticsearch.md), you can do that now. 
+
+## Additional Information
+
+[Search Administration and Tuning](../../search_administration_and_tuning.md)

--- a/docs/dxp/7.x/en/using-search/installing-and-upgrading-a-search-engine/search-upgrade-paths.md
+++ b/docs/dxp/7.x/en/using-search/installing-and-upgrading-a-search-engine/search-upgrade-paths.md
@@ -1,0 +1,34 @@
+# Search Upgrade Paths 
+
+The following table provides the steps for upgrading from your current Liferay installation to Liferay 7.3 and a supported search engine stacks. 
+
+Find the scenario that matches your Liferay version and Liferay Enterprise Search (LES) version (if you're using LES), and your current search engine stack. The *Upgrade Steps* column summarizes your upgrade.
+
+| Scenario | Liferay Version \[+ LES Version\] | Search Engine Stack | Upgrade Steps |
+| :-- | :-------- | :---------------- | :-------------- |
+| 1.  | **Liferay 7.2** | Elasticsearch 7.9+ | 1. [Connect Liferay to Elasticsearch 7.](./elasticsearch/connecting-to-elasticsearch.md)<br><br>2. [Configure security.](./elasticsearch/securing-elasticsearch.md)<br><br>3. [Upgrade Liferay.](../../installation-and-upgrades/upgrading-liferay/upgrade-basics/upgrade-overview.md)<br><br>4. [Re-index search & spell check indexes.](../../installation-and-upgrades/upgrading-liferay/upgrade-basics/post-upgrade-considerations.md) |
+| 2.  | **Liferay 7.2 + LES 3.0** (*Monitoring*, *Learning to Rank*) | Elasticsearch 7.9+ | 1. Connect Liferay to Elasticsearch 7.<br><br>2. Configure security.<br><br>3. Install Kibana 7.9+ if you are currently using *Kibana and Monitoring*.<br><br>4. Install and deploy LES Monitoring if you are currently using Kibana and *Elasticsearch Monitoring/X-Pack Monitoring*.<br><br>5. Configure the *Elasticsearch Monitoring* connector if you are using *LES Monitoring* or *Connector to X-Pack Monitoring*.<br><br>6. [Upgrade Liferay.](../../installation-and-upgrades/upgrading-liferay/upgrade-basics/upgrade-overview.md)<br><br>7. [Re-index search & spell check indexes.](../../installation-and-upgrades/upgrading-liferay/upgrade-basics/post-upgrade-considerations.md) |
+| 3.  | **Liferay 7.2** | Elasticsearch 7.3.x-7.8.x | 1. [Install Elasticsearch 7.9+.](./elasticsearch/installing-elasticsearch.md)<br><br>2. Follow *Scenario 1.* |
+| 4.  | **Liferay 7.2 + LES 2.0** (*Monitoring*, *Learning to Rank*) | Elasticsearch 7.3.x-7.8.x | 1. [Install Elasticsearch 7.9+.](./elasticsearch/installing-elasticsearch.md)<br><br>2. Follow *Scenario 2.* |
+| 5.  | **Liferay 7.2** | Elasticsearch 6.x | 1. [Install Elasticsearch 7.9+.](./elasticsearch/installing-elasticsearch.md)<br><br>2. Follow *Scenario 1.* |
+| 6.  | **Liferay 7.2 + LES 2.0** (*Monitoring*, *Learning to Rank*) | Elasticsearch 6.x | 1. [Install Elasticsearch 7.9+.](./elasticsearch/installing-elasticsearch.md)<br><br>2. Follow *Scenario 2.* |
+| 7.  | **Liferay 7.1** | Elasticsearch 6.x | 1. [Install Elasticsearch 7.9+.](./elasticsearch/installing-elasticsearch.md)<br><br>2. Follow *Scenario 1.* |
+| 8.  | **Liferay 7.1 + LES 2.0** (*Monitoring*, *Learning to Rank*) | Elasticsearch 6.x | 1. [Install Elasticsearch 7.9+.](./elasticsearch/installing-elasticsearch.md)<br><br>2. Follow *Scenario 2.* |
+| 9.  | **Liferay 7.0** | Elasticsearch 6.x | 1. [Install Elasticsearch 7.9+.](./elasticsearch/installing-elasticsearch.md)<br><br>2. Follow *Scenario 1.* |
+| 10. | **Liferay 7.0 + LES 2.0** (*Monitoring*, *Learning to Rank*) | Elasticsearch 5.x | 1. [Install Elasticsearch 7.9+.](./elasticsearch/installing-elasticsearch.md)<br><br>2. Follow *Scenario 2.* |
+| 11. | **Liferay 7.0** | Elasticsearch 2.x | 1. [Install Elasticsearch 7.9+.](./elasticsearch/installing-elasticsearch.md)<br><br>2. Follow *Scenario 1.* |
+| 12. | **Liferay 7.2, 7.1** | Solr 7.x | **Switch to Elasticsearch:**<br><br>1. [Install Elasticsearch 7.9+.](./elasticsearch/installing-elasticsearch.md)<br><br>2. Follow *Scenario 1* for configuring Liferay 7.3 with Elasticsearch<br> or follow *Scenario 2* for Liferay 7.3 + Liferay Enterprise Search (LES) 3.0<br><br>**or**<br><br><br>**Upgrade Solr (deprecated):**<br><br>1. [Set up Solr 8.x.](./solr.md)<br><br>2. [Upgrade Liferay.](../../installation-and-upgrades/upgrading-liferay/upgrade-basics/upgrade-overview.md)<br><br>3. [Re-index search & spell check indexes.](../../installation-and-upgrades/upgrading-liferay/upgrade-basics/post-upgrade-considerations.md) |
+| 13. | **Liferay 7.0** | Solr 5.x | Same as *Scenario 12.* |
+
+## What's Next 
+
+Now that you know your upgrade path, start upgrading to use Liferay 7.3 with the latest [Elasticsearch](./elasticsearch/upgrading-elasticsearch.md) (*recommended*) or [Solr](./solr.md) (now deprecated as of Liferay 7.3) search engine.
+
+## Additional Information 
+
+* [Upgrading Elasticsearch](./elasticsearch/getting-started-with-elasticsearch.md)
+* [Getting Started with Elasticsearch](./elasticsearch/getting-started-with-elasticsearch.md)
+* [Installing Elasticsearch](./elasticsearch/installing-elasticsearch.md)
+* [Connecting to Elasticsearch](./elasticsearch/connecting-to-elasticsearch.md)
+* [Securing Elasticsearch](./elasticsearch/securing-elasticsearch.md)
+* [Upgrading Liferay](../../installation-and-upgrades/upgrading-liferay/upgrade-basics/upgrade-overview.md)

--- a/docs/dxp/7.x/en/using-search/installing-and-upgrading-a-search-engine/upgrading-search.md
+++ b/docs/dxp/7.x/en/using-search/installing-and-upgrading-a-search-engine/upgrading-search.md
@@ -1,0 +1,27 @@
+# Upgrading Search
+
+Liferay 7.3 brings [new improvements](../getting-started/whats-new-in-search-for-73.md) for search. You must upgrade to them. Elasticsearch 7.9 is the minimum version required for Liferay 7.3. The [compatibility matrix](https://help.liferay.com/hc/en-us/sections/360002103292-Compatibility-Matrix) provides the latest support details.
+
+```important::
+   Solr integration is now deprecated as of Liferay 7.3. Elasticsearch integration replaces it. Migrating to Elasticsearch requires `setting up Elasticsearch `<./elasticsearch/getting-started-with-elasticsearch.md>`_ and `connecting Liferay <./elasticsearch/connecting-to-elasticsearch.md`_ to it.
+```
+
+```important::
+   Elasticsearch 6.x is not supported on Liferay 7.3.
+```
+
+Here are the general upgrade steps:
+
+1. Back up your search indexes.
+1. Set up the latest supported search engine.
+1. Set up Liferay's connector to that search engine.
+1. Configure security.
+1. Upgrade the Liferay database.
+1. Re-index search indexes.
+
+Examine [Search Upgrade Paths](./search-upgrade-paths.md) first because it summarizes upgrading from search stacks on previous Liferay versions to the latest supported search stack. Then [back up your search indexes]((./elasticsearch/backing-up-elasticsearch.md)) before [upgrading search](./elasticsearch/upgrading-elasticsearch.md).
+
+## Additional information
+
+* [Backing Up Elasticsearch](./elasticsearch/backing-up-elasticsearch.md)
+* [Upgrading Elasticsearch](./elasticsearch/upgrading-elasticsearch.md)

--- a/docs/dxp/7.x/en/using-search/installing_and_upgrading_a_search_engine.rst
+++ b/docs/dxp/7.x/en/using-search/installing_and_upgrading_a_search_engine.rst
@@ -7,8 +7,10 @@ Installing and Upgrading a Search Engine
    installing-and-upgrading-a-search-engine/installing-a-search-engine.md
    installing-and-upgrading-a-search-engine/elasticsearch.rst
    installing-and-upgrading-a-search-engine/solr.rst
+   installing-and-upgrading-a-search-engine/search-upgrade-paths.md
 
 -  :doc:`/using-search/installing-and-upgrading-a-search-engine/installing-a-search-engine`
+-  :doc:`/using-search/installing-and-upgrading-a-search-engine/search-upgrade-paths`
 
 Elasticsearch
 -------------
@@ -21,6 +23,7 @@ Elasticsearch
 -  :doc:`/using-search/installing-and-upgrading-a-search-engine/elasticsearch/troubleshooting-elasticsearch-installation`
 -  :doc:`/using-search/installing-and-upgrading-a-search-engine/elasticsearch/exercise-installing-elasticsearch`
 -  :doc:`/using-search/installing-and-upgrading-a-search-engine/elasticsearch/using-the-sidecar-or-embedded-elasticsearch`
+-  :doc:`/using-search/installing-and-upgrading-a-search-engine/elasticsearch/backing-up-elasticsearch`
 
 
 Solr


### PR DESCRIPTION
Welcome back Russ!

To support the search upgrade docs (not yet written), I drafted a version of Tibor's upgrade paths table (from his Grow article) and ported our instructions for backing up Elasticsearch. 

In Search Upgrade Paths, I reorganized the rows to be for upgrading from the latest Liferay versions first. I also put the Liferay rows before Liferay + LES, which has more steps. 

I hope this is helpful! Ping me when you want. 

Jim