### PR TITLE
liferay-learn scripting | script for initial java project creation | dev-tutorials

### DIFF
--- a/docs/init_java_example.sh
+++ b/docs/init_java_example.sh
@@ -5,51 +5,51 @@ readonly CURRENT_DIR_NAME=$(dirname "${0}")
 readonly ZIP_DIR_NAME=$(find . -name liferay-${1}.zip -type d)
     
 function init_project {
-    if [[ -z ${ZIP_DIR_NAME} ]]
-    then
-        echo "FAILED: Target directory does not exist. Create a liferay-${1}.zip folder, then try again."
-        exit
-    elif [ "$(ls -A ${ZIP_DIR_NAME})" ]
-    then
-        echo "$(ls -A ${ZIP_DIR_NAME})"
-        echo "FAILED: Target directory is not empty, cannot initialize a project"
-        exit
-    else
-        local inner_project_dir_name=${ZIP_DIR_NAME}/${1}-ptype
+	if [[ -z ${ZIP_DIR_NAME} ]]
+	then
+		echo "FAILED: Target directory does not exist. Create a liferay-${1}.zip folder, then try again."
+		exit
+	elif [ "$(ls -A ${ZIP_DIR_NAME})" ]
+	then
+		echo "$(ls -A ${ZIP_DIR_NAME})"
+		echo "FAILED: Target directory is not empty, cannot initialize a project"
+		exit
+	else
+		local inner_project_dir_name=${ZIP_DIR_NAME}/${1}-ptype
 
-        mkdir -p ${inner_project_dir_name}/src/main/java/
-        mkdir -p ${inner_project_dir_name}/src/main/resources/content/
-        mkdir -p ${inner_project_dir_name}/src/main/resources/META-INF/resources/
+		mkdir -p ${inner_project_dir_name}/src/main/java/
+		mkdir -p ${inner_project_dir_name}/src/main/resources/content/
+		mkdir -p ${inner_project_dir_name}/src/main/resources/META-INF/resources/
 
-        local build_gradle_contents="dependencies {\n\tcompileOnly group: \"com.liferay.portal\", name: \"release.portal.api\"\n}"
-        
-        echo -ne "${build_gradle_contents}" > ${inner_project_dir_name}/build.gradle
+		local build_gradle_contents="dependencies {\n\tcompileOnly group: \"com.liferay.portal\", name: \"release.portal.api\"\n}"
 
-        local bnd_bnd_contents="Bundle-Name: Acme $(echo ${1} | tr [:lower:] [:upper:]) PTYPE\nBundle-SymbolicName: com.acme.${1}.ptype\nBundle-Version: 1.0.0"
+		echo -ne "${build_gradle_contents}" > ${inner_project_dir_name}/build.gradle
 
-        echo -ne "${bnd_bnd_contents}" > ${inner_project_dir_name}/bnd.bnd
-    fi
+		local bnd_bnd_contents="Bundle-Name: Acme $(echo ${1} | tr [:lower:] [:upper:]) PTYPE\nBundle-SymbolicName: com.acme.${1}.ptype\nBundle-Version: 1.0.0"
+
+		echo -ne "${bnd_bnd_contents}" > ${inner_project_dir_name}/bnd.bnd
+	fi
 }
 
 function log_next_steps {
-    echo ""
-    echo "--------------"
-    echo "NEXT: Make sure you replace \"ptype\" with a project type (usually api, impl, or web) in this directory name:"
-    echo "$(find ${ZIP_DIR_NAME} -name "*ptype*" -type d)"
-    echo ""
-    echo "--------------"
-    echo "NEXT: Make sure you replace \"ptype\" with a project type (usually api, impl, or web) in these files' contents:"
-    echo "$(grep -ir "ptype" ${ZIP_DIR_NAME})"
+	echo ""
+	echo "--------------"
+	echo "NEXT: Make sure you replace \"ptype\" with a project type (usually api, impl, or web) in this directory name:"
+	echo "$(find ${ZIP_DIR_NAME} -name "*ptype*" -type d)"
+	echo ""
+	echo "--------------"
+	echo "NEXT: Make sure you replace \"ptype\" with a project type (usually api, impl, or web) in these files' contents:"
+	echo "$(grep -ir "ptype" ${ZIP_DIR_NAME})"
 }
 
 function main {
 	pushd "${CURRENT_DIR_NAME}" || exit 1
 
-    init_project ${1}
+	init_project ${1}
 
-    ./update_examples.sh ${1}
+	./update_examples.sh ${1}
 
-    log_next_steps
+	log_next_steps
 }
 
 main "${@}"

--- a/docs/init_java_example.sh
+++ b/docs/init_java_example.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+readonly CURRENT_DIR_NAME=$(dirname "${0}")
+
+readonly ZIP_DIR_NAME=$(find . -name liferay-${1}.zip -type d)
+    
+function init_project {
+    if [[ -z ${ZIP_DIR_NAME} ]]
+    then
+        echo "FAILED: Target directory does not exist. Create a liferay-${1}.zip folder, then try again."
+        exit
+    elif [ "$(ls -A ${ZIP_DIR_NAME})" ]
+    then
+        echo "$(ls -A ${ZIP_DIR_NAME})"
+        echo "FAILED: Target directory is not empty, cannot initialize a project"
+        exit
+    else
+        local inner_project_dir_name=${ZIP_DIR_NAME}/${1}-ptype
+
+        mkdir -p ${inner_project_dir_name}/src/main/java/
+        mkdir -p ${inner_project_dir_name}/src/main/resources/content/
+        mkdir -p ${inner_project_dir_name}/src/main/resources/META-INF/resources/
+
+        local build_gradle_contents="dependencies {\n\tcompileOnly group: \"com.liferay.portal\", name: \"release.portal.api\"\n}"
+        
+        echo -ne "${build_gradle_contents}" > ${inner_project_dir_name}/build.gradle
+
+        local bnd_bnd_contents="Bundle-Name: Acme $(echo ${1} | tr [:lower:] [:upper:]) PTYPE\nBundle-SymbolicName: com.acme.${1}.ptype\nBundle-Version: 1.0.0"
+
+        echo -ne "${bnd_bnd_contents}" > ${inner_project_dir_name}/bnd.bnd
+    fi
+}
+
+function log_next_steps {
+    echo ""
+    echo "--------------"
+    echo "NEXT: Make sure you replace \"ptype\" with a project type (usually api, impl, or web) in this directory name:"
+    echo "$(find ${ZIP_DIR_NAME} -name "*ptype*" -type d)"
+    echo ""
+    echo "--------------"
+    echo "NEXT: Make sure you replace \"ptype\" with a project type (usually api, impl, or web) in these files' contents:"
+    echo "$(grep -ir "ptype" ${ZIP_DIR_NAME})"
+}
+
+function main {
+	pushd "${CURRENT_DIR_NAME}" || exit 1
+
+    init_project ${1}
+
+    ./update_examples.sh ${1}
+
+    log_next_steps
+}
+
+main "${@}"

--- a/docs/init_java_example.sh
+++ b/docs/init_java_example.sh
@@ -25,7 +25,11 @@ function init_project {
 
 		echo -ne "${build_gradle_contents}" > ${inner_project_dir_name}/build.gradle
 
-		local bnd_bnd_contents="Bundle-Name: Acme $(echo ${1} | tr [:lower:] [:upper:]) PTYPE\nBundle-SymbolicName: com.acme.${1}.ptype\nBundle-Version: 1.0.0"
+		local bundle_name="Bundle-Name: Acme $(echo ${1} | tr [:lower:] [:upper:]) PTYPE"
+		local bundle_symbolic_name="Bundle-SymbolicName: com.acme.${1}.ptype"
+		local bundle_version="Bundle-Version: 1.0.0"
+
+		local bnd_bnd_contents="${bundle_name}\n${bundle_symbolic_name}\n${bundle_version}"
 
 		echo -ne "${bnd_bnd_contents}" > ${inner_project_dir_name}/bnd.bnd
 	fi
@@ -34,11 +38,11 @@ function init_project {
 function log_next_steps {
 	echo ""
 	echo "--------------"
-	echo "NEXT: Make sure you replace \"ptype\" with a project type (usually api, impl, or web) in this directory name:"
+	echo "NEXT: Replace \"ptype\" with a project type (usually api, impl, or web) in this directory name:"
 	echo "$(find ${ZIP_DIR_NAME} -name "*ptype*" -type d)"
 	echo ""
 	echo "--------------"
-	echo "NEXT: Make sure you replace \"ptype\" with a project type (usually api, impl, or web) in these files' contents:"
+	echo "NEXT: Replace \"ptype\" with a project type (usually api, impl, or web) in these files' contents:"
 	echo "$(grep -ir "ptype" ${ZIP_DIR_NAME})"
 }
 


### PR DESCRIPTION
There seemed to be a gap in our workflow for creating developer code samples, and I've sought to address it in this `init_java_example.sh` script. It sits in the `docs` folder with `update_examples.sh`, and does these things:

1. Takes the 4-character project ID (e.g., a1b2) as an argument, and creates the inner project's directory structure (e.g. `a1b2-impl`), but doesn't assume a project type, instead uses a key the writer will need to replace manually, `ptype` (e.g., `a1b2-ptype`)
    ```
    a1b2-ptype/src/main/java
    a1b2-ptype/src/main/resources
    a1b2-ptype/src/main/resources/META-INF/resources
    ```
    > The parent folder, `liferay-a1b2.zip`, must be present before running this (error logging is printed if this folder doesn't exist).
1. Create initial `build.gradle` and `bnd.bnd` files with reasonable starting content:
    ```
    Bundle-Name: Acme Z4Y7 PTYPE
    Bundle-SymbolicName: com.acme.z4y7.ptype
    Bundle-Version: 1.0.0
    ```
    ```
    dependencies {
         compileOnly group: "com.liferay.portal", name: "release.portal.api"
    }
1. Run `./update_examples.sh a1b2` to get the build infrastructure created in the .zip folder
1. Print some next steps to make sure the `ptype` key is replaced with a real project type:
    ```
    --------------
    NEXT: Replace "ptype" with a project type (usually api, impl, or web) in this directory name:
    ./dxp/7.x/en/using-search/developer-guide/searching-programmatically/resources/liferay-z4y7.zip/z4y7-ptype
    
    --------------
    NEXT: Replace "ptype" with a project type (usually api, impl, or web) in these files' contents:
    ./dxp/7.x/en/using-search/developer-guide/searching-programmatically/resources/liferay-z4y7.zip/z4y7-ptype/bnd.bnd:Bundle-Name: Acme Z4Y7 PTYPE
    ./dxp/7.x/en/using-search/developer-guide/searching-programmatically/resources/liferay-z4y7.zip/z4y7-ptype/bnd.bnd:Bundle-SymbolicName: com.acme.z4y7.ptype
    ```

