### PR TITLE
Refactor ZIP file creation to move contents to example dir and zip it to th target ZIP file

### DIFF
--- a/site/build_site.sh
+++ b/site/build_site.sh
@@ -181,17 +181,14 @@ function generate_static_html {
 			pushd ${zip_dir_name}/../
 
 			local zip_file_name=$(basename "${zip_dir_name}")
-			local zip_file_parent_dir_name=$(echo ${zip_file_name} | cut -d'.' -f1)
 
-			mv ${zip_file_name} ${zip_file_parent_dir_name}
+			local example_dir_name=$(echo ${zip_file_name} | cut -d'.' -f1)
 
-			mkdir ${zip_file_name}
+			mkdir ${example_dir_name}
 
-			mv ${zip_file_parent_dir_name} ${zip_file_name}
+			mv ${zip_file_name}/* ${zip_file_name}/.gradle ${example_dir_name}
 
-			pushd ${zip_file_name}
-
-			zip -r ${zip_file_name} .
+			zip -r ${zip_file_name}/${zip_file_name} ${example_dir_name}
 
 			local output_dir_name=$(dirname "${zip_dir_name}")
 
@@ -203,7 +200,6 @@ function generate_static_html {
 			output_dir_name=$(dirname "${output_dir_name}")
 			output_dir_name=${output_dir_name/input/output}
 
-			popd
 			popd
 
 			mkdir -p "${output_dir_name}"

--- a/site/build_site.sh
+++ b/site/build_site.sh
@@ -178,9 +178,18 @@ function generate_static_html {
 
 		for zip_dir_name in $(find build/input/"${product_version_language_dir_name}" -name *.zip -type d)
 		do
-			pushd "${zip_dir_name}"
+			pushd ${zip_dir_name}/../
 
 			local zip_file_name=$(basename "${zip_dir_name}")
+			local zip_file_parent_dir_name=$(echo ${zip_file_name} | cut -d'.' -f1)
+
+			mv ${zip_file_name} ${zip_file_parent_dir_name}
+
+			mkdir ${zip_file_name}
+
+			mv ${zip_file_parent_dir_name} ${zip_file_name}
+
+			pushd ${zip_file_name}
 
 			zip -r ${zip_file_name} .
 
@@ -194,6 +203,7 @@ function generate_static_html {
 			output_dir_name=$(dirname "${output_dir_name}")
 			output_dir_name=${output_dir_name/input/output}
 
+			popd
 			popd
 
 			mkdir -p "${output_dir_name}"

--- a/site/build_site.sh
+++ b/site/build_site.sh
@@ -186,7 +186,12 @@ function generate_static_html {
 
 			mkdir ${example_dir_name}
 
-			mv ${zip_file_name}/* ${zip_file_name}/.gradle ${example_dir_name}
+			mv ${zip_file_name}/* ${example_dir_name}
+
+			if [ -d ${zip_file_name}/.gradle ]
+			then
+				mv ${zip_file_name}/.gradle ${example_dir_name}
+			fi
 
 			zip -r ${zip_file_name}/${zip_file_name} ${example_dir_name}
 


### PR DESCRIPTION
Hi Russ,

Thanks for helping me with debugging my problem with running this script! I found that my attempt to move files matching `.*` (e.g., `.gradle`) included an attempt to move the actual source directory (e.g., `liferay-r1s1.zip/.`) which caused the script to fail immediately at that point. So I'm now I'm specifically matching the .gradle file (e.g.,`liferay-xxxx.zip/.gradle`).

Here's a summary of the refactored logic:
1. Make a separate example dir (`liferay-xxxx/`) for the ZIP contents.
2. Move the files from `liferay-xxxx.zip/ `to `liferay-xxxx/`, making sure to include the `.gradle` hidden folder.
3. ZIP `liferay-xxxx/` to `liferay-xxxx.zip/liferay-xxxx.zip` 

Let me know what you think. Thanks!